### PR TITLE
Add lookupByEmail methods for users

### DIFF
--- a/packages/slack/src/api/users.ts
+++ b/packages/slack/src/api/users.ts
@@ -8,4 +8,7 @@ export class Users extends APIModule {
 
   list = () =>
     this.request('list').then(get<User[]>('members'))
+
+  lookupByEmail = (email: string) =>
+    this.request('lookupByEmail', { email }).then(get<User>('user'))
 }


### PR DESCRIPTION
This adds a method `lookupByEmail` to get a User object by email - https://api.slack.com/methods/users.lookupByEmail

Before in order to get a User object you had to download all user list and filter it. 